### PR TITLE
Update build_tarballs.jl

### DIFF
--- a/C/CryptoMiniSat/build_tarballs.jl
+++ b/C/CryptoMiniSat/build_tarballs.jl
@@ -6,12 +6,12 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "CryptoMiniSat"
-version = v"5.8.2"
-cryptominisat_version = v"5.8.0"
+version = v"5.8.3"
+cryptominisat_version = v"5.11.4"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/msoos/cryptominisat.git", "e7079937ed2bfe9160a104378e5a344028e4ab78"),
+    GitSource("https://github.com/msoos/cryptominisat.git", "219a457501fd0796bd871bd6b3735b130598430"),
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
I believe I did everything I should: upgraded the package version (5.8.3), the library version (5.11.4) and the commit hash from github.

The new release of cryptominisat seems much better at handling xor clauses, which is what I need.